### PR TITLE
Integrate Swift Concurrency API over the app

### DIFF
--- a/Appetizers/Network/NetworkManager.swift
+++ b/Appetizers/Network/NetworkManager.swift
@@ -18,39 +18,20 @@ final class NetworkManager {
     private init() {}
     
     // MARK: - Internal Methods
-    func getAppetizers(completed: @escaping (Result<[Appetizer], APError>) -> Void) {
+    func getAppetizers() async throws -> [Appetizer] {
         guard let url = URL(string: appetizersURL) else {
-            completed(.failure(.invalidURL))
-            return
+            throw APError.invalidURL
         }
         
-        let task = URLSession.shared.dataTask(with: URLRequest(url: url)) { data, response, error in
-            if let _ = error {
-                completed(.failure(.unableToComplete))
-                return
-            }
-            
-            guard let response = response as? HTTPURLResponse, response.statusCode == 200 else {
-                completed(.failure(.invalidResponse))
-                return
-            }
-            
-            guard let data = data else {
-                completed(.failure(.invalidData))
-                return
-            }
-            
-            do {
-                let decoder = JSONDecoder()
-                let decodedResponse = try decoder.decode(AppetizerResponse.self, from: data)
-                
-                completed(.success(decodedResponse.request))
-            } catch {
-                completed(.failure(.invalidData))
-            }
-        }
+        let (data, response) = try await URLSession.shared.data(from: url)
         
-        task.resume()
+        do {
+            let decoder = JSONDecoder()
+            
+            return try decoder.decode(AppetizerResponse.self, from: data).request
+        } catch {
+            throw APError.invalidData
+        }
     }
     
     func downloadImage(fromURLString urlString: String, completed: @escaping (UIImage?) -> Void) {

--- a/Appetizers/Scenes/AppetizerListView/AppetizerListView.swift
+++ b/Appetizers/Scenes/AppetizerListView/AppetizerListView.swift
@@ -25,7 +25,7 @@ struct AppetizerListView: View {
                 .listStyle(.plain)
                 .disabled(viewModel.isShowingDetail)
             }
-            .onAppear {
+            .task {
                 viewModel.getAppetizers()
             }
             .blur(radius: viewModel.isShowingDetail ? 20 : 0)


### PR DESCRIPTION
## Objective
Integrate the Swift Concurrency API over the app using the async/await.

For the `NetworkLayer` class, only the method `getAppetizers` was marked with Concurrency because the `downloadImage` will receive an integration with the `AsyncImage` component of SwiftUI.

It's also interesting to notice that the `AppetizerListViewModel` now implements a `Task` to work over asynchronous operation and it's market with the `@MainActor` notation, avoiding thread problems while integrating this layer with the View.

**References**

_Swift Concurrency Manifesto_
https://gist.github.com/lattner/31ed37682ef1576b16bca1432ea9f782