### PR TITLE
Integrate `AsyncImage` component on list cell

### DIFF
--- a/Appetizers/Views/Cells/AppetizerListCell.swift
+++ b/Appetizers/Views/Cells/AppetizerListCell.swift
@@ -12,10 +12,20 @@ struct AppetizerListCell: View {
     
     var body: some View {
         HStack {
-            AppetizerRemoteImage(urlString: appetizer.imageURL)
-                .aspectRatio(contentMode: .fit)
-                .frame(width: 120, height: 90)
-                .cornerRadius(8)
+            AsyncImage(url: URL(string: appetizer.imageURL)) { image in
+                image
+                    .resizable()
+                    .aspectRatio(contentMode: .fit)
+                    .frame(width: 120, height: 90)
+                    .cornerRadius(8)
+            } placeholder: {
+                Image(.foodPlaceholder)
+                    .resizable()
+                    .aspectRatio(contentMode: .fit)
+                    .frame(width: 120, height: 90)
+                    .cornerRadius(8)
+            }
+
             
             VStack(alignment: .leading, spacing: 5) {
                 Text(appetizer.name)


### PR DESCRIPTION
## Objective
Integrate the `AsyncImage` SwiftUI Component into the `AppetizerListCell` view.

This component allow us to download an image using the `URLSession` directly from our component, only passing a valid `URL`.

There's also an interesting point on `AsyncImage` that's the `placeholder` parameter, letting us put an `Image` while our asset is being downloaded or in case of an error, we use it as the `Image` to be displayed.

**Important**
Using `AsyncImage` is really easy, but it's important to notice that the component by itself doesn't offer us the possibility to implement a cache strategy.

If you're using this into a large list of items, it's extremely recommended to integrate `AsyncImage` with a cache strategy.

**Reference**
https://developer.apple.com/documentation/swiftui/asyncimage