### PR TITLE
Refactor: integrate `Observation` framework on project

### DIFF
--- a/Appetizers/Scenes/AccountView/AccountView.swift
+++ b/Appetizers/Scenes/AccountView/AccountView.swift
@@ -8,7 +8,7 @@
 import SwiftUI
 
 struct AccountView: View {
-    @StateObject private var viewModel: AccountViewModel = AccountViewModel()
+    @State private var viewModel: AccountViewModel = AccountViewModel()
     @FocusState private var focusedTextField: FormTextField?
     
     enum FormTextField {

--- a/Appetizers/Scenes/AccountView/AccountViewModel.swift
+++ b/Appetizers/Scenes/AccountView/AccountViewModel.swift
@@ -5,13 +5,18 @@
 //  Created by Gabriel Pereira on 11/07/24.
 //
 
+import Observation
 import SwiftUI
 
-final class AccountViewModel: ObservableObject {
+@Observable
+final class AccountViewModel {
     // MARK: - Properties
-    @AppStorage("user") private var userData: Data?
-    @Published var user: User = User()
-    @Published var alertItem: AlertItem?
+    @ObservationIgnored
+    @AppStorage("user")
+    private var userData: Data?
+    
+    var user: User = User()
+    var alertItem: AlertItem?
     
     // MARK: - Computed Properties
     var isValidForm: Bool {

--- a/Appetizers/Scenes/AppetizerListView/AppetizerListView.swift
+++ b/Appetizers/Scenes/AppetizerListView/AppetizerListView.swift
@@ -7,8 +7,9 @@
 
 import SwiftUI
 
+@MainActor
 struct AppetizerListView: View {
-    @StateObject var viewModel = AppetizerListViewModel()
+    @State var viewModel = AppetizerListViewModel()
     
     var body: some View {
         ZStack {

--- a/Appetizers/Scenes/AppetizerListView/AppetizerListViewModel.swift
+++ b/Appetizers/Scenes/AppetizerListView/AppetizerListViewModel.swift
@@ -5,15 +5,17 @@
 //  Created by Gabriel Pereira on 18/02/24.
 //
 
+import Observation
 import SwiftUI
 
 @MainActor
+@Observable
 final class AppetizerListViewModel: ObservableObject {
-    @Published var appetizers: [Appetizer] = []
-    @Published var alertItem: AlertItem?
-    @Published var isLoading: Bool = false
-    @Published var isShowingDetail: Bool = false
-    @Published var selectedAppetizer: Appetizer?
+    var appetizers: [Appetizer] = []
+    var alertItem: AlertItem?
+    var isLoading: Bool = false
+    var isShowingDetail: Bool = false
+    var selectedAppetizer: Appetizer?
     
     // MARK: - Internal Methods
     func getAppetizers() {

--- a/Appetizers/Scenes/AppetizerListView/AppetizerListViewModel.swift
+++ b/Appetizers/Scenes/AppetizerListView/AppetizerListViewModel.swift
@@ -10,7 +10,7 @@ import SwiftUI
 
 @MainActor
 @Observable
-final class AppetizerListViewModel: ObservableObject {
+final class AppetizerListViewModel {
     var appetizers: [Appetizer] = []
     var alertItem: AlertItem?
     var isLoading: Bool = false

--- a/Appetizers/Scenes/AppetizerListView/AppetizerListViewModel.swift
+++ b/Appetizers/Scenes/AppetizerListView/AppetizerListViewModel.swift
@@ -8,8 +8,8 @@
 import Observation
 import SwiftUI
 
-@MainActor
 @Observable
+@MainActor
 final class AppetizerListViewModel {
     var appetizers: [Appetizer] = []
     var alertItem: AlertItem?


### PR DESCRIPTION
## Context
This pull requests introduces the [`Observation`](https://developer.apple.com/documentation/observation) framework in the app.

As part of the release of iOS 17, the Observation framework provides a new way to handle with `ObservableObject` in our app.

As reference, I used the [following article](https://infinum.com/blog/swiftui-observation/) to change the implementation of the app.

We can see that in the code below that instead of marking the view model classes with the `ObservableObject` protocol and the properties that are being observed with the `@Published` property wrapper, now, we add the `@Observable` macro on the top of our class, which creates a boilerplate for our code.

```swift
// Approach without using `Observation` framework
final class AccountViewModel: ObservableObject {
    @Published var user: User = User()
}

// Using `Observation` framework
@Observable
final class AccountViewModel {
    var user: User = User()
}
```

Other important aspect is the way we consume our view model. Now, instead of declaring inside our `View` as a `@StateObject`, we turn the view model property in a `@State` property:

```swift
// Approach without using `Observation` framework
struct AccountView: View {
    @State private var viewModel: AccountViewModel = AccountViewModel()
}

// Using `Observation` framework
struct AccountView: View {
    @State private var viewModel: AccountViewModel = AccountViewModel()
}
```

One important observation is that the **Observation** framework is only supported in iOS 17+, so, the old way will still be used in many contexts, since many production applications gave support for targets older than iOS 17.

Since this app is a study app, we can add into an isolated branch here and use it 😉.